### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+exadrums (0.4.1-2) UNRELEASED; urgency=medium
+
+  * Use secure URI in Homepage field.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 00:55:12 +0000
+
 exadrums (0.4.1-1) unstable; urgency=medium
 
   * New upstream version.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
 exadrums (0.4.1-2) UNRELEASED; urgency=medium
 
   * Use secure URI in Homepage field.
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 00:55:12 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ exadrums (0.4.1-2) UNRELEASED; urgency=medium
   * Use secure URI in Homepage field.
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
     Repository-Browse.
+  * Update standards version to 4.5.0, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 00:55:12 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Build-Depends:
  pkg-config,
 Standards-Version: 4.4.0
 Rules-Requires-Root: no
-Homepage: http://www.freewebmaster.fr
+Homepage: https://www.freewebmaster.fr
 Vcs-Browser: https://github.com/SpintroniK/eXaDrums
 Vcs-Git: https://github.com/SpintroniK/eXaDrums.git -b debian
 

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Build-Depends:
  libexadrums-dev,
  libgtkmm-3.0-dev,
  pkg-config,
-Standards-Version: 4.4.0
+Standards-Version: 4.5.0
 Rules-Requires-Root: no
 Homepage: https://www.freewebmaster.fr
 Vcs-Browser: https://github.com/SpintroniK/eXaDrums

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,4 @@
+Bug-Database: https://github.com/SpintroniK/eXaDrums/issues
+Bug-Submit: https://github.com/SpintroniK/eXaDrums/issues/new
+Repository: https://github.com/SpintroniK/eXaDrums.git
+Repository-Browse: https://github.com/SpintroniK/eXaDrums


### PR DESCRIPTION
Fix some issues reported by lintian
* Use secure URI in Homepage field. ([homepage-field-uses-insecure-uri](https://lintian.debian.org/tags/homepage-field-uses-insecure-uri.html))
* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository.html))
* Update standards version to 4.5.0, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/exadrums/32c0d8ae-1d9a-4c3e-b7a7-9cfb038f34c2.


## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files of package exadrums: lines which differ (wdiff format)
* Homepage: [-http&#8203;://www.freewebmaster.fr-] {+https&#8203;://www.freewebmaster.fr+}

No differences were encountered between the control files of package \*\*exadrums-dbgsym\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/32c0d8ae-1d9a-4c3e-b7a7-9cfb038f34c2/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/32c0d8ae-1d9a-4c3e-b7a7-9cfb038f34c2/diffoscope)).
